### PR TITLE
Add -liconv to LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.9.1
 
 DEBUG=-g
-LDFLAGS=-lmrss $(DEBUG)
+LDFLAGS=-liconv -lmrss $(DEBUG)
 CFLAGS=-O2 -Wall -DVERSION=\"$(VERSION)\" $(DEBUG)
 
 OBJS=r2t.o


### PR DESCRIPTION
I wasn't able to get this to build without adding `-liconv` to LDFLAGS (and having libiconv available, of course).
