### PR TITLE
*encoding fixes (issue #11)

### DIFF
--- a/r2t.c
+++ b/r2t.c
@@ -439,6 +439,10 @@ int main(int argc, char *argv[])
 			return 2;
 		}
 
+		if (data_cur[cur_url]->encoding == NULL) {
+			data_cur[cur_url]->encoding = "utf-8";
+		}
+
 		if (verbose)
 			printf("Creating converter %s -> %s\n", data_cur[cur_url] -> encoding, current_encoding);
 


### PR DESCRIPTION
*encoding in mrss_t can be NULL and this lead in crashing rsstail because it is
not NULL checked. If it is NULL set the default encoding to utf-8.
Closes Issue #11.
