### PR TITLE
Add support for the guid tag. Fix issue #3.

### DIFF
--- a/r2t.c
+++ b/r2t.c
@@ -139,6 +139,7 @@ void usage(void)
 	printf("-p      show publication date\n");
 	printf("-a      show author\n");
 	printf("-c      show comments\n");
+	printf("-g	show guid\n");
 	printf("-N      do not show headings\n");
 	printf("-b x	limit description/comments to x bytes\n");
 	printf("-z      continue even if there are XML parser errors in the RSS feed\n");
@@ -169,7 +170,7 @@ int main(int argc, char *argv[])
 	char *proxy = NULL, *proxy_auth = NULL;
 	int sw = 0;
 	int verbose = 0;
-	char show_timestamp = 0, show_link = 0, show_description = 0, show_pubdate = 0, show_author = 0, show_comments = 0;
+	char show_timestamp = 0, show_link = 0, show_description = 0, show_pubdate = 0, show_author = 0, show_comments = 0, show_guid = 0;
 	char strip_html = 0, no_error_exit = 0;
 	char one_shot = 0;
 	char no_heading = 0;
@@ -186,7 +187,7 @@ int main(int argc, char *argv[])
 
 	memset(&mot, 0x00, sizeof(mot));
 
-	while((sw = getopt(argc, argv, "A:Z:1b:PHztldrpacu:Ni:n:x:y:vVh")) != -1)
+	while((sw = getopt(argc, argv, "A:Z:1b:PHztldrpacgu:Ni:n:x:y:vVh")) != -1)
 	{
 		switch(sw)
 		{
@@ -293,6 +294,10 @@ int main(int argc, char *argv[])
 
 			case 'c':
 				show_comments = 1;
+				break;
+
+			case 'g':
+				show_guid = 1;
 				break;
 
 			case 'u':
@@ -595,6 +600,9 @@ int main(int argc, char *argv[])
 						free(comments);
 					}
 				}
+
+				if (show_guid && item_cur -> guid != NULL)
+					printf("%s%s\n", no_heading?" ":"guid: ", item_cur -> guid);
 			}
 
 			item_cur = item_cur -> next;

--- a/rsstail.1
+++ b/rsstail.1
@@ -27,6 +27,8 @@ Show Publication date
 Show author
 .IP "\fB\-c\fB" 10
 Show comments
+.IP "\fB\-g\fB" 10
+Show guid
 .IP "\fB\-b X\fB" 10
 Where X is the limit in bytes for description/comments
 .IP "\fB\-z\fB" 10


### PR DESCRIPTION
As discussed in issue #3 this pull request add supports for the guid tag. 

Please note that the "guid" in libmrss terminology is the `<guid>` tag for RSS 2.0 feeds and the `<id>` tag for Atom feeds.