### PR TITLE
Update option descriptions in manpage and help message

### DIFF
--- a/r2t.c
+++ b/r2t.c
@@ -133,30 +133,30 @@ void usage(void)
 {
 	version();
 
-	printf("-t	show timestamp\n");
-	printf("-l	show link\n");
-	printf("-e	show enclosure URL\n");
-	printf("-d	show description\n");
-	printf("-p	show publication date\n");
-	printf("-a	show author\n");
-	printf("-c	show comments\n");
-	printf("-g	show guid\n");
+	printf("-t	show a timestamp of when the item was processed\n");
+	printf("-l	show item's link\n");
+	printf("-e	show item's enclosure URL\n");
+	printf("-d	show item's description\n");
+	printf("-p	show item's publication date\n");
+	printf("-a	show item's author\n");
+	printf("-c	show item's comments\n");
+	printf("-g	show item's GUID\n");
 	printf("-N	do not show headings\n");
 	printf("-b x	limit description/comments to x bytes\n");
 	printf("-z	continue even if there are XML parser errors in the RSS feed\n");
-	printf("-Z x	add heading 'x'\n");
-	printf("-n x	initially show x items\n");
+	printf("-Z x	print string 'x' before headings\n");
+	printf("-n x	initially show only first 'x' items\n");
 	printf("-r	reverse output, so it looks more like an RSS feed\n");
 	printf("-H	strip HTML tags\n");
 	/*	printf("-o x    only show items newer then x[s/M/h/d/m/y]\n");	*/
-	printf("-A x	authenticate against webserver, x is in format username:password\n");
+	printf("-A x	authenticate against webserver (username:password)\n");
 	printf("-u url	URL of RSS feed to tail\n");
 	printf("-i x	check interval in seconds (default is 15min)\n");
 	printf("-x x	proxy server to use (host[:port])\n");
-	printf("-y x	proxy authorization (user:password)\n");
+	printf("-y x	proxy authentication (username:password)\n");
 	printf("-P	do not exit when an error occurs\n");
-	printf("-1	one shot\n");
-	printf("-v	be verbose (add more to be more verbose)\n");
+	printf("-1	one shot mode: print new items and exit\n");
+	printf("-v	be verbose (repeat to increase verbosity)\n");
 	printf("-V	show version and exit\n");
 	printf("-h	this help\n");
 }

--- a/rsstail.1
+++ b/rsstail.1
@@ -31,17 +31,21 @@ Show author
 Show comments
 .IP "\fB\-g\fB" 10
 Show guid
+.IP "\fB\-N\fB" 10
+Do not show headings
 .IP "\fB\-b X\fB" 10
 Where X is the limit in bytes for description/comments
 .IP "\fB\-z\fB" 10
 Continue even if there are XML parser errors in the RSS 
 feed.
+.IP "\fB\-Z string\fB" 10
+Output user-specified string before all the other headings
 .IP "\fB\-n X\fB" 10
 Initially show X items
 .IP "\fB\-H\fB" 10
 Strip HTML tags
-.IP "\fB\-o X\fB" 10
-only show items newer than X[s/M/h/d/m/y]
+.IP "\fB\-A username:password\fB" 10
+Authenticate against webserver
 .IP "\fB\-u URL\fB" 10
 URL of RSS feed to tai
 .IP "\fB\-i Seconds\fB" 10
@@ -54,6 +58,8 @@ proxy server to use (host[:port])
 proxy authorization (user:password)
 .IP "\fB\-P\fB" 10
 do not exit when an error occurs
+.IP "\fB\-1\fB" 10
+One shot mode: check the feeds for updates, print it out and quit
 .IP "\fB\-v\fB" 10
 be verbose (add more to be more verbose)
 .IP "\fB\-h\fP" 10 

--- a/rsstail.1
+++ b/rsstail.1
@@ -1,6 +1,6 @@
 .TH "RSSTAIL" "1" "0.1" "" "User Commands"
 .SH "NAME"
-rsstail a Console Based RSS news reader 
+rsstail \- a console RSS reader that monitors feeds and outputs new entries
 .SH "SYNOPSIS"
 .PP 
 \fBrsstail\fR [\fBOPTIONS\fB]... \fB\-u\fB URL 
@@ -10,68 +10,71 @@ This manual page was written for the \fBDebian\fP distribution
 because the original program does not have a manual page. 
 .PP 
 
-Parse a RSS feed and read it, in an output similar to the tail command.
+rsstail fetches RSS feeds from specified URLs and outputs them continuously, 
+much like \fBtail -f\fB does with files.
 .SH "OPTIONS"
 .PP 
-This is a Few Description on the main options for rsstail
+Options can be given in any order. Options that don't have an argument can be 
+combined after a single dash.
  
 .IP "\fB\-t\fP" 10
-Show timestamp.
+Show a timestamp of when the item was processed
 .IP "\fB\-l\fP" 10
-Show link
+Show item's link
 .IP "\fB\-e\fP" 10
-Show enclosure URL
+Show item's enclosure URL
 .IP "\fB\-d\fB" 10
-Show Description
+Show item's description
 .IP "\fB\-p\fB" 10
-Show Publication date
+Show item's publication date
 .IP "\fB\-a\fB" 10
-Show author
+Show item's author
 .IP "\fB\-c\fB" 10
-Show comments
+Show item's comments
 .IP "\fB\-g\fB" 10
-Show guid
+Show item's GUID
 .IP "\fB\-N\fB" 10
 Do not show headings
 .IP "\fB\-b X\fB" 10
-Where X is the limit in bytes for description/comments
+Limit description and comments to \fBX\fB bytes
 .IP "\fB\-z\fB" 10
 Continue even if there are XML parser errors in the RSS 
-feed.
+feed
 .IP "\fB\-Z string\fB" 10
 Output user-specified string before all the other headings
 .IP "\fB\-n X\fB" 10
-Initially show X items
+Initially show only first \fBX\fB items
 .IP "\fB\-H\fB" 10
 Strip HTML tags
 .IP "\fB\-A username:password\fB" 10
 Authenticate against webserver
 .IP "\fB\-u URL\fB" 10
-URL of RSS feed to tai
-.IP "\fB\-i Seconds\fB" 10
-check interval in seconds (default is 15 minutes)
+URL of RSS feed to tail
+.IP "\fB\-i seconds\fB" 10
+Check interval in seconds (default is 15 minutes)
 .IP "\fB\-r\fB"
-Print in reverse order
-.IP "\fB\-x Proxy\fB" 10
-proxy server to use (host[:port])
-.IP "\fB\-y ProxyAuth\fB" 10
-proxy authorization (user:password)
+Print items in reverse order
+.IP "\fB\-x host[:port]\fB" 10
+Proxy server to use
+.IP "\fB\-y username:password\fB" 10
+Credentials for the proxy server
 .IP "\fB\-P\fB" 10
-do not exit when an error occurs
+Do not exit when an error occurs
 .IP "\fB\-1\fB" 10
-One shot mode: check the feeds for updates, print it out and quit
+One shot mode: check the feeds for new items, print them out and exit
 .IP "\fB\-v\fB" 10
-be verbose (add more to be more verbose)
+Be verbose (repeat to increase verbosity)
 .IP "\fB\-h\fP" 10 
-Help output
+Show options and their descriptions
 .IP "\fB\-V\fP" 10 
-Show version of program. 
+Show version of the program
 .SH "AUTHOR"
 .PP 
 This manual page was written by Rene Mayorga <rmayorga@debian.org.sv> for 
 the \fBDebian\fP system (but may be used by others).  Permission is 
 granted to copy, distribute and/or modify this document under 
-the terms of the GNU General Public License, Version 2 any later version published by the Free Software Foundation. 
+the terms of the GNU General Public License, Version 2 or any later version 
+published by the Free Software Foundation. 
  
 .PP 
 On Debian systems, the complete text of the GNU General Public 


### PR DESCRIPTION
Hi,

You almost lost a user to poor documentation :) Someone came to #newsbeuter chat asking if Newsbeuter can be used to grab RSS feeds and print them to stdout, claiming `rsstail` can't do that because it lacks one-shot mode. Turns out it doesn't, it just makes the appropriate switch harder to find than it should be. Hope this PR will help with fixing that.